### PR TITLE
refactor: rename type-based icon helper

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -914,7 +914,7 @@ class Terminal {
         const fileElement = document.createElement('div');
         fileElement.className = 'file-item';
         fileElement.innerHTML = `
-            <div class="file-icon">${this.getFileIcon(type)}</div>
+            <div class="file-icon">${this.getIconByType(type)}</div>
             <div class="file-info">
                 <div class="file-name">${filename}</div>
                 <div class="file-type">${type}</div>
@@ -935,7 +935,7 @@ class Terminal {
         }
     }
     
-    getFileIcon(type) {
+    getIconByType(type) {
         switch (type) {
             case 'image': return '🖼️';
             case 'audio': return '🎵';


### PR DESCRIPTION
## Summary
- rename the earlier `getFileIcon` helper to `getIconByType`
- update `addFileToPanel` to use `getIconByType`
- keep extension-based `getFileIcon` for determining icons from filenames

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688decc54a808327956e1d0c25da5e6e