### PR TITLE
Display message count and enable real-time updates

### DIFF
--- a/web/firebase.js
+++ b/web/firebase.js
@@ -1,0 +1,48 @@
+// Firebase initialization and Firestore realtime utilities
+import { initializeApp, getApps, getApp } from 'https://www.gstatic.com/firebasejs/12.1.0/firebase-app.js';
+import { getFirestore, collection, onSnapshot } from 'https://www.gstatic.com/firebasejs/12.1.0/firebase-firestore.js';
+
+// Your web app's Firebase configuration
+const firebaseConfig = {
+  apiKey: "AIzaSyBVjT-lp95QrRjIXj72ReAiktrPEJLuMIQ",
+  authDomain: "mansion-espiritus-lkgoxs.firebaseapp.com",
+  databaseURL: "https://mansion-espiritus-lkgoxs.firebaseio.com",
+  projectId: "mansion-espiritus-lkgoxs",
+  storageBucket: "mansion-espiritus-lkgoxs.firebasestorage.app",
+  messagingSenderId: "997389903772",
+  appId: "1:997389903772:web:88d82929f2593fe6744a59",
+  measurementId: "G-KJ2VGH8RL2"
+};
+
+// Ensure single app instance
+let appInstance;
+try {
+  appInstance = getApps().length ? getApp() : initializeApp(firebaseConfig);
+} catch (e) {
+  // Fallback in case getApps/getApp are unavailable
+  appInstance = initializeApp(firebaseConfig);
+}
+
+const db = getFirestore(appInstance);
+
+// Subscribe to realtime message count for a given game code
+export function subscribeToMessageCount(gameCode, onCountChange) {
+  if (!gameCode || typeof onCountChange !== 'function') {
+    return () => {};
+  }
+  const messagesRef = collection(db, 'twin-islands', gameCode, 'messages');
+  const unsubscribe = onSnapshot(
+    messagesRef,
+    (snapshot) => {
+      try {
+        onCountChange(snapshot.size);
+      } catch (callbackError) {
+        console.error('Error in onCountChange callback:', callbackError);
+      }
+    },
+    (error) => {
+      console.error('Firestore onSnapshot error:', error);
+    }
+  );
+  return unsubscribe;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -15,7 +15,7 @@
                 <div class="button minimize"></div>
                 <div class="button maximize"></div>
             </div>
-            <div class="terminal-title" id="terminalTitle">dron@johnson:~</div>
+            <div class="terminal-title" id="terminalTitle">dron@johnson:~ <span id="messageCount" style="opacity:0.8; font-weight:600;"></span></div>
             <div class="reset-button-container">
                 <button class="reset-button" id="resetButton" title="Resetear juego y conversaciones">
                     <span class="reset-icon">🔄</span>


### PR DESCRIPTION
Integrate Firebase Firestore to display real-time message count next to the terminal title.

---
<a href="https://cursor.com/background-agent?bcId=bc-424910b7-0387-4e93-87f1-3685fe8c16e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-424910b7-0387-4e93-87f1-3685fe8c16e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

