### PR TITLE
Fix terminal title overlap on android

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Terminal Web</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">

--- a/web/styles.css
+++ b/web/styles.css
@@ -7,15 +7,18 @@
 body {
     font-family: 'JetBrains Mono', monospace;
     background: linear-gradient(135deg, #1e1e1e, #2d2d2d);
-    height: 100vh;
+    height: 100vh; /* fallback */
+    height: 100dvh; /* mobile-friendly dynamic viewport */
     margin: 0;
     padding: 0;
+    padding-top: env(safe-area-inset-top);
     overflow: hidden;
 }
 
 .terminal-container {
     width: 100vw;
-    height: 100vh;
+    height: 100vh; /* fallback */
+    height: 100dvh; /* dynamic viewport to avoid URL bar overlap */
     background: #0c0c0c;
     overflow: hidden;
     display: flex;
@@ -25,10 +28,13 @@ body {
 
 .terminal-header {
     background: #2d2d2d;
-    padding: 10px 15px;
+    padding: calc(10px + env(safe-area-inset-top)) 15px 10px 15px;
     display: flex;
     align-items: center;
     border-bottom: 1px solid #404040;
+    position: sticky;
+    top: 0;
+    z-index: 2;
 }
 
 .terminal-buttons {
@@ -764,4 +770,9 @@ body {
     .tab-text {
         font-size: 10px;
     }
+} 
+
+@supports (height: 100svh) {
+    body { height: 100svh; }
+    .terminal-container { height: 100svh; }
 } 


### PR DESCRIPTION
Adjusts viewport height and header positioning to prevent the terminal title from being obscured by the browser's address bar on mobile.

On some Android devices, the `100vh` unit incorrectly includes the browser's address bar in the viewport height, causing content at the top (like the terminal header) to be pushed underneath it. This PR uses `100dvh` (dynamic viewport height) and `100svh` (small viewport height) for more accurate height calculations, along with `viewport-fit=cover` and `safe-area-inset-top` to properly handle safe areas and ensure the header remains visible and sticky at the top.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9cb9eb7-0822-4152-b7e4-bbb2cea03344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9cb9eb7-0822-4152-b7e4-bbb2cea03344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

