### PR TITLE
Ajustar mensaje de foto para realidad 00f0

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -1506,6 +1506,12 @@ class Terminal {
                         this.showAttachments(messageObj.photoUrls);
                     } else {
                         this.addOutputLine(messageObj.message, 'drone-message');
+                        if (
+                            config.currentTheme === 'blue' &&
+                            messageObj.photoUrls && Array.isArray(messageObj.photoUrls) && messageObj.photoUrls.length > 0
+                        ) {
+                            this.addOutputLine('📎 Foto enviada', 'attachments');
+                        }
                     }
                 } else {
                     // Mensaje genérico (fallback)


### PR DESCRIPTION
Add '📎 Foto enviada' indicator for drone messages with photos in 'blue' theme to clarify photo presence without displaying thumbnails.

---
<a href="https://cursor.com/background-agent?bcId=bc-712b1b98-62a6-450d-b5a9-c27b77d9326e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-712b1b98-62a6-450d-b5a9-c27b77d9326e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

